### PR TITLE
Fix the issue when flatline is not triggering when it first run

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -574,7 +574,8 @@ class FlatlineRule(FrequencyRule):
             self.first_event[key] = most_recent_ts
 
         # Don't check for matches until timeframe has elapsed
-        if most_recent_ts - self.first_event[key] < self.rules['timeframe']:
+        first_query_ts = self.first_event[key] - self.rules['timeframe']
+        if most_recent_ts - first_query_ts <= self.rules['timeframe']:
             return
 
         # Match if, after removing old events, we hit num_events
@@ -1149,7 +1150,7 @@ class PercentageMatchRule(BaseAggregationRule):
         for filter_doc in copy.deepcopy(filters):
             if 'meta' in filter_doc:
                 del filter_doc['meta']
-            if '$state' in filter:
+            if '$state' in filter_doc:
                 del filter_doc['$state']
             match_bucket_filter_without_meta.append(filter_doc)
         return match_bucket_filter_without_meta

--- a/tests/rules_test.py
+++ b/tests/rules_test.py
@@ -839,7 +839,8 @@ def test_flatline_count():
     rule.add_count_data({ts_to_dt('2014-10-11T00:00:15'): 0})
     rule.garbage_collect(ts_to_dt('2014-10-11T00:00:20'))
     assert len(rule.matches) == 0
-    rule.add_count_data({ts_to_dt('2014-10-11T00:00:35'): 0})
+    # Should be sufficient to signal a 30s timeframe has elapsed.
+    rule.add_count_data({ts_to_dt('2014-10-11T00:00:30'): 0})
     assert len(rule.matches) == 1
 
 
@@ -866,7 +867,7 @@ def test_flatline_query_key():
     rule.add_data([create_event(ts_to_dt('2014-09-26T12:00:20Z'), qk='key3')])
 
     # key1 and key2 have not had any new data, so they will trigger the flatline alert
-    timestamp = '2014-09-26T12:00:45Z'
+    timestamp = '2014-09-26T12:00:30Z'  # Should be sufficient to signal a 30s timeframe has elapsed.
     rule.garbage_collect(ts_to_dt(timestamp))
     assert len(rule.matches) == 2
     assert set(['key1', 'key2']) == set([m['key'] for m in rule.matches if m['@timestamp'] == timestamp])


### PR DESCRIPTION
because it thinks it didn't query the duration of the timeframe
configuration.
- It is a simple off by one error.