### PR TITLE
fix(SES-479): Ensure frequency don't resent occurences that are not

### DIFF
--- a/elastalert/ruletypes.py
+++ b/elastalert/ruletypes.py
@@ -267,12 +267,19 @@ class FrequencyRule(RuleType):
         # Match if, after removing old events, we hit num_events.
         # the 'end' parameter depends on whether this was called from the
         # middle or end of an add_data call and is used in subclasses
-        if self.occurrences[key].count() >= self.rules['num_events']:
-            event = self.occurrences[key].data[-1][0]
+        timeframe_occurences_count = self.occurrences[key].count()
+        if timeframe_occurences_count >= self.rules['num_events']:
+            elastalert_logger.info("Match triggered! {} (> {}) events occured in the last timeframe".format(
+                timeframe_occurences_count, self.rules['num_events']))
+            # Sonar: Added deep copies here and there since some "event" fields will be stringified at some point
+            # down the line.
+            event = copy.deepcopy(self.occurrences[key].data[-1][0])
             if self.attach_related:
-                event['related_events'] = [data[0] for data in self.occurrences[key].data[:-1]]
+                event['related_events'] = [copy.deepcopy(data[0]) for data in self.occurrences[key].data[:-1]]
             self.add_match(event)
-            self.occurrences.pop(key)
+            # Sonar: This is responsible for this ugly behaviour, as documented by one of the mainatainers:
+            #   :see https://github.com/Yelp/elastalert/issues/807#issuecomment-263678089
+            # self.occurrences.pop(key)
 
     def garbage_collect(self, timestamp):
         """ Remove all occurrence data that is beyond the timeframe away """


### PR DESCRIPTION
  stale
- Right now, there is a bug upstream in which frequency won't trigger
  again, until timeframe later when there is a match.
- It does this by wiping out all history of the last timeframe.
- The fix involves, not wiping out the last timeframe history.