### PR TITLE
Alexander/Compare rules updates

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -568,7 +568,7 @@ class ElastAlerter():
         return {endtime: res['count']}
 
     def get_hits_terms(self, rule, starttime, endtime, index, key, qk=None, size=None):
-        rule = copy.deepcopy(rule)
+        rule = rule.copy()
 
         if 'filter' in rule:
             rule_filter = copy.copy(rule['filter'])

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -35,6 +35,7 @@ from elasticsearch.exceptions import TransportError
 from enhancements import DropMatchException
 from rule_type_definitions.frequency_rules import FlatlineRule
 from rule_type_definitions.compare_rules import BlacklistRule, WhitelistRule, ChangeRule
+from rule_type_definitions.cardinality_rule import CardinalityRule
 from saved_source_factory import SavedSourceFactory
 from util import add_raw_postfix
 from util import cronite_datetime_to_timestamp
@@ -1009,6 +1010,7 @@ class ElastAlerter():
         segment_size = self.get_segment_size(rule)
 
         tmp_endtime = rule['starttime']
+
 
         while endtime - rule['starttime'] > segment_size:
             tmp_endtime = tmp_endtime + segment_size

--- a/elastalert/rule_type_definitions/cardinality_rule.py
+++ b/elastalert/rule_type_definitions/cardinality_rule.py
@@ -16,7 +16,7 @@ class CardinalityRule(RuleType):
         self.cardinality_cache = {}
         self.first_event = {}
         self.timeframe = self.rules['timeframe']
-        self.rules['use_run_every_query_size'] = True
+        # self.rules['use_run_every_query_size'] = True
         self.rules['realert'] = timedelta(0)
         self.rules['aggregation_query_element'] = self.generate_aggregation_query()
 

--- a/elastalert/rule_type_definitions/compare_rules.py
+++ b/elastalert/rule_type_definitions/compare_rules.py
@@ -85,7 +85,8 @@ class BlacklistRule(CompareRule):
 
         self.item_clauses = self.generate_item_clauses(self.rules['blacklist'], self.rules['compare_key'])
 
-        self.rules['aggregation_query_element'] = self.generate_aggregation_query(self.rules['compare_key'])
+        if self.rules['bundle_alerts']:
+            self.rules['aggregation_query_element'] = self.generate_aggregation_query(self.rules['compare_key'])
 
     def compare(self, event):
         return True
@@ -105,7 +106,8 @@ class WhitelistRule(CompareRule):
         super(WhitelistRule, self).__init__(rules, args=None)
         self.expand_entries('whitelist')
         self.item_clauses = self.generate_item_clauses(self.rules['whitelist'], self.rules['compare_key'])
-        self.rules['aggregation_query_element'] = self.generate_aggregation_query(self.rules['compare_key'])
+        if self.rules['bundle_alerts']:
+            self.rules['aggregation_query_element'] = self.generate_aggregation_query(self.rules['compare_key'])
 
     def compare(self, event):
         return True

--- a/elastalert/rule_type_definitions/compare_rules.py
+++ b/elastalert/rule_type_definitions/compare_rules.py
@@ -85,8 +85,8 @@ class BlacklistRule(CompareRule):
 
         self.item_clauses = self.generate_item_clauses(self.rules['blacklist'], self.rules['compare_key'])
 
-        if self.rules['bundle_alerts']:
-            self.rules['aggregation_query_element'] = self.generate_aggregation_query(self.rules['compare_key'])
+        # if self.rules['bundle_alerts']:
+        self.rules['aggregation_query_element'] = self.generate_aggregation_query(self.rules['compare_key'])
 
     def compare(self, event):
         return True
@@ -106,8 +106,8 @@ class WhitelistRule(CompareRule):
         super(WhitelistRule, self).__init__(rules, args=None)
         self.expand_entries('whitelist')
         self.item_clauses = self.generate_item_clauses(self.rules['whitelist'], self.rules['compare_key'])
-        if self.rules['bundle_alerts']:
-            self.rules['aggregation_query_element'] = self.generate_aggregation_query(self.rules['compare_key'])
+        # if self.rules['bundle_alerts']:
+        self.rules['aggregation_query_element'] = self.generate_aggregation_query(self.rules['compare_key'])
 
     def compare(self, event):
         return True

--- a/elastalert/rule_type_definitions/frequency_rules.py
+++ b/elastalert/rule_type_definitions/frequency_rules.py
@@ -124,6 +124,7 @@ class FlatlineRule(FrequencyRule):
             # Do a deep-copy, otherwise we lose the datetime type in the timestamp field of the last event
             event = copy.deepcopy(self.occurrences[key].data[-1][0])
             event.update(key=key, count=count)
+            elastalert_logger.warning('event: {}'.format(event))
             self.add_match(event)
 
             if not self.rules.get('forget_keys'):

--- a/elastalert/rule_type_definitions/frequency_rules.py
+++ b/elastalert/rule_type_definitions/frequency_rules.py
@@ -169,3 +169,5 @@ class FlatlineRule(FrequencyRule):
                 ({self.ts_field: ts}, 0)
             )
             self.first_event.setdefault(key, ts)
+            if self.rules.get('query_key'):
+                self.check_for_match(key)

--- a/elastalert/rule_type_definitions/frequency_rules.py
+++ b/elastalert/rule_type_definitions/frequency_rules.py
@@ -1,4 +1,5 @@
 import copy
+from datetime import timedelta
 
 from elastalert.rule_type_definitions.ruletypes import RuleType, EventWindow
 from elastalert.util import (EAException, new_get_event_ts, hashable, lookup_es_key, elastalert_logger, pretty_ts, dt_to_ts,
@@ -24,6 +25,7 @@ class FrequencyRule(RuleType):
 
         event = ({self.ts_field: ts}, count)
         self.occurrences.setdefault('all', EventWindow(self.rules['timeframe'], getTimestamp=self.get_ts)).append(event)
+        elastalert_logger.warning('check for matches in add count data')
         self.check_for_match('all')
 
     def add_terms_data(self, terms):
@@ -32,6 +34,7 @@ class FrequencyRule(RuleType):
                 event = ({self.ts_field: timestamp,
                           self.rules['query_key']: bucket['key']}, bucket['doc_count'])
                 self.occurrences.setdefault(bucket['key'], EventWindow(self.rules['timeframe'], getTimestamp=self.get_ts)).append(event)
+                elastalert_logger.warning('check for matches in add terms data')
                 self.check_for_match(bucket['key'])
 
     def add_data(self, data):
@@ -49,11 +52,13 @@ class FrequencyRule(RuleType):
 
             # Store the timestamps of recent occurrences, per key
             self.occurrences.setdefault(key, EventWindow(self.rules['timeframe'], getTimestamp=self.get_ts)).append((event, 1))
+            elastalert_logger.warning('check for matches in add data 1')
             self.check_for_match(key, end=False)
 
         # We call this multiple times with the 'end' parameter because subclasses
         # may or may not want to check while only partial data has been added
         if key in self.occurrences:  # could have been emptied by previous check
+            elastalert_logger.warning('check for matches in add data 2')
             self.check_for_match(key, end=True)
 
     def check_for_match(self, key, end=False):
@@ -98,7 +103,9 @@ class FlatlineRule(FrequencyRule):
     required_options = frozenset(['timeframe', 'threshold'])
 
     def __init__(self, *args):
+        # self.rules['realert'] = timedelta(10)
         super(FlatlineRule, self).__init__(*args)
+        self.rules['realert'] = timedelta(0)
         self.threshold = self.rules['threshold']
 
         # Dictionary mapping query keys to the first events
@@ -162,4 +169,3 @@ class FlatlineRule(FrequencyRule):
                 ({self.ts_field: ts}, 0)
             )
             self.first_event.setdefault(key, ts)
-            self.check_for_match(key)

--- a/elastalert/rule_type_definitions/ruletypes.py
+++ b/elastalert/rule_type_definitions/ruletypes.py
@@ -41,7 +41,6 @@ class RuleType(object):
         """
         # Convert datetime's back to timestamps
         ts = self.rules.get('timestamp_field')
-        # TODO take a look at what the event actually look like, since they seem to be most of the returned doc
         if ts in event:
             event[ts] = dt_to_ts(event[ts])
 

--- a/elastalert/rule_type_definitions/ruletypes.py
+++ b/elastalert/rule_type_definitions/ruletypes.py
@@ -41,6 +41,7 @@ class RuleType(object):
         """
         # Convert datetime's back to timestamps
         ts = self.rules.get('timestamp_field')
+        # TODO take a look at what the event actually look like, since they seem to be most of the returned doc
         if ts in event:
             event[ts] = dt_to_ts(event[ts])
 


### PR DESCRIPTION
Rewrites the three compare rules use a combination of queries and aggregations to get matches rather than running a query and then checking each data point in python.

Also add supports for the ignore null flag in change_rule, and white-list, and allows blacklisting null values and empty strings as per SES-420.

Also Fixes  SES-415.