### PR TITLE
SES: New Terms Rule big data fix

### DIFF
--- a/elastalert/constants.py
+++ b/elastalert/constants.py
@@ -3,5 +3,5 @@ SYSLOG_DEFAULT_HOST = '127.0.0.1'
 SYSLOG_DEFAULT_PORT = 514
 SYSLOG_DEFAULT_PROTOCOL = 'udp'
 
-NEW_TERM_DB = 'test'
-NEW_TERM_COLL = 'test_new_terms'
+NEW_TERM_DB = 'lmrm__sonarg'
+NEW_TERM_COLL = 'lmrm__elastalert_new_terms_reference'

--- a/elastalert/constants.py
+++ b/elastalert/constants.py
@@ -2,3 +2,6 @@ DISPATCHER_CONF = '/opt/sonarfinder/sonarFinder/dispatcher.conf'
 SYSLOG_DEFAULT_HOST = '127.0.0.1'
 SYSLOG_DEFAULT_PORT = 514
 SYSLOG_DEFAULT_PROTOCOL = 'udp'
+
+NEW_TERM_DB = 'test'
+NEW_TERM_COLL = 'test_new_terms'

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -694,7 +694,6 @@ class ElastAlerter():
         :param end: The latest time to query.
         Returns True on success and False on failure.
         """
-        elastalert_logger.warning('_______________running_query____________')
         if start is None:
             start = self.get_index_start(get_index_util(rule))
         if end is None:
@@ -957,7 +956,6 @@ class ElastAlerter():
         :param endtime: The latest timestamp to query.
         :return: The number of matches that the rule produced.
         """
-        elastalert_logger.warning('_____________Running_rule__________________')
         run_start = time.time()
 
         self.current_es = elasticsearch_client(rule)

--- a/elastalert/rule_type_definitions/new_terms_rule.py
+++ b/elastalert/rule_type_definitions/new_terms_rule.py
@@ -1,10 +1,10 @@
-import copy
 import datetime
-import sys
+import ConfigParser
 
+from elastalert.constants import DISPATCHER_CONF, NEW_TERM_DB, NEW_TERM_COLL
 from elastalert.rule_type_definitions.ruletypes import RuleType
 from elastalert.util import (add_raw_postfix, EAException, elastalert_logger, elasticsearch_client, format_index, get_index,
-                             lookup_es_key, ts_to_dt, ts_now)
+lookup_es_key, ts_to_dt, ts_now, get_sonar_connection)
 
 
 class NewTermsRule(RuleType):
@@ -12,272 +12,105 @@ class NewTermsRule(RuleType):
 
     def __init__(self, rule, args=None):
         super(NewTermsRule, self).__init__(rule, args)
-        self.seen_values = {}
-        # Allow the use of query_key or fields
-        if 'fields' not in self.rules:
-            if 'query_key' not in self.rules:
-                raise EAException("fields or query_key must be specified")
-            self.fields = self.rules['query_key']
-        else:
-            self.fields = self.rules['fields']
-        if not self.fields:
-            raise EAException("fields must not be an empty list")
-        if type(self.fields) != list:
-            self.fields = [self.fields]
-        if self.rules.get('use_terms_query') and \
-                (len(self.fields) != 1 or (len(self.fields) == 1 and type(self.fields[0]) == list)):
-            raise EAException("use_terms_query can only be used with a single non-composite field")
-        if self.rules.get('use_terms_query'):
-            if [self.rules['query_key']] != self.fields:
-                raise EAException('If use_terms_query is specified, you cannot specify different query_key and fields')
-            if not self.rules.get('query_key').endswith('.keyword') and not self.rules.get('query_key').endswith('.raw'):
-                if self.rules.get('use_keyword_postfix', True):
-                    elastalert_logger.warn('Warning: If query_key is a non-keyword field, you must set '
-                                           'use_keyword_postfix to false, or add .keyword/.raw to your query_key.')
-        try:
-            self.get_all_terms(args)
-        except Exception as e:
-            # Refuse to start if we cannot get existing terms
-            raise EAException('Error searching for existing terms: %s' % (repr(e))), None, sys.exc_info()[2]
+        self.rules['use_run_every_query_size'] = True
+        self.rules['realert'] = datetime.timedelta(0)
+        self.agg_key = None
+        self.rules['aggregation_query_element'] = self.generate_aggregation_query(self.rules['query_key'])
 
-    def get_all_terms(self, args):
-        """ Performs a terms aggregation for each field to get every existing term. """
+        conf = ConfigParser.ConfigParser()
+        conf.read(DISPATCHER_CONF)
+        uri = conf.get('dispatch', 'sonarw_uri')
+
+        self.sonar_con = get_sonar_connection(uri)
+        self.terms_collection = self.sonar_con[NEW_TERM_DB][NEW_TERM_COLL]
+        elastalert_logger.warning('___________init New Terms RUle_______________')
+
+        self.terms_collection.insert_one({'rule': self.rules['name'],
+                                          'term': 'lmrm__SONAR_ALERT_RULE_ACTIVE__',
+                                          'time': datetime.datetime.utcnow()})
+
         self.es = elasticsearch_client(self.rules)
-        window_size = datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
-        field_name = {"field": "", "size": 2147483647}  # Integer.MAX_VALUE
-        query_template = {"aggs": {"values": {"terms": field_name}}}
-        if args and hasattr(args, 'start') and args.start:
-            end = ts_to_dt(args.start)
-        elif 'start_date' in self.rules:
-            end = ts_to_dt(self.rules['start_date'])
-        else:
-            end = ts_now()
-        start = end - window_size
-        step = datetime.timedelta(**self.rules.get('window_step_size', {'days': 1}))
 
-        for field in self.fields:
-            tmp_start = start
-            tmp_end = min(start + step, end)
+        self.initialized = False
 
-            time_filter = {self.rules['timestamp_field']: {'lt': self.rules['dt_to_ts'](tmp_end), 'gte': self.rules['dt_to_ts'](tmp_start)}}
-            query_template['filter'] = {'bool': {'must': [{'range': time_filter}]}}
-            query = {'aggs': {'filtered': query_template}}
+    def generate_aggregation_query(self, key):
+        self.agg_key = key
+        agg_query = {'{}'.format(key): {'terms': {'field': key}}}
+        return agg_query
 
-            if 'filter' in self.rules:
-                for item in self.rules['filter']:
-                    query_template['filter']['bool']['must'].append(item)
+    def add_aggregation_data(self, payload):
+        for timestamp, payload_data in payload.iteritems():
+            self.check_matches(timestamp, payload_data)
 
-            # For composite keys, we will need to perform sub-aggregations
-            if type(field) == list:
-                self.seen_values.setdefault(tuple(field), [])
-                level = query_template['aggs']
-                # Iterate on each part of the composite key and add a sub aggs clause to the elastic search query
-                for i, sub_field in enumerate(field):
-                    if self.rules.get('use_keyword_postfix', True):
-                        level['values']['terms']['field'] = add_raw_postfix(sub_field, self.is_five_or_above())
-                    else:
-                        level['values']['terms']['field'] = sub_field
-                    if i < len(field) - 1:
-                        # If we have more fields after the current one, then set up the next nested structure
-                        level['values']['aggs'] = {'values': {'terms': copy.deepcopy(field_name)}}
-                        level = level['values']['aggs']
-            else:
-                self.seen_values.setdefault(field, [])
-                # For non-composite keys, only a single agg is needed
-                if self.rules.get('use_keyword_postfix', True):
-                    field_name['field'] = add_raw_postfix(field, self.is_five_or_above())
-                else:
-                    field_name['field'] = field
+    def check_matches(self, timestamp, aggregation_data):
+        terms_list = [item['key'] for item in aggregation_data['bucket_aggs']['buckets']]
+        elastalert_logger.warning('terms list = {}'.format(terms_list))
+        end_window = self.rules['starttime']
+        start_window = self.rules['starttime'] - datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
+        elastalert_logger.warning('startwindow: {}  endwindow: {}'.format(start_window, end_window))
+        pipe = [{'$match': {'$and': [{'rule': self.rules['name']},
+                                     {'time': {'$lte': end_window}},
+                                     {'time': {'$gte': start_window}}]}},
+                {'$group': {'_id': '$rule', 'vals': {'$addToSet': "$term"}}},
+                {'$project': {
+                    'new_terms': {'$filter': {'input': terms_list, 'as': 'value', 'cond': {'$not': {
+                        '$setIsSubset': [['$$value'], '$vals']}
+                    }}}}}]
 
-            # Query the entire time range in small chunks
-            while tmp_start < end:
-                if self.rules.get('use_strftime_index'):
-                    index = format_index(get_index(self.rules), tmp_start, tmp_end)
-                else:
-                    index = get_index(self.rules)
-                res = self.es.search(body=query, index=index, ignore_unavailable=True, timeout='50s')
-                if 'aggregations' in res:
-                    buckets = res['aggregations']['filtered']['values']['buckets']
-                    if type(field) == list:
-                        # For composite keys, make the lookup based on all fields
-                        # Make it a tuple since it can be hashed and used in dictionary lookups
-                        for bucket in buckets:
-                            # We need to walk down the hierarchy and obtain the value at each level
-                            self.seen_values[tuple(field)] += self.flatten_aggregation_hierarchy(bucket)
-                    else:
-                        keys = [bucket['key'] for bucket in buckets]
-                        self.seen_values[field] += keys
-                else:
-                    if type(field) == list:
-                        self.seen_values.setdefault(tuple(field), [])
-                    else:
-                        self.seen_values.setdefault(field, [])
-                if tmp_start == tmp_end:
-                    break
-                tmp_start = tmp_end
-                tmp_end = min(tmp_start + step, end)
-                time_filter[self.rules['timestamp_field']] = {'lt': self.rules['dt_to_ts'](tmp_end),
-                                                              'gte': self.rules['dt_to_ts'](tmp_start)}
+        new_terms = list(self.terms_collection.aggregate(pipe))[0]['new_terms']
+        elastalert_logger.warning('new_terms = {}'.format(new_terms))
+        time_now = end_window + datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))/2
+        elastalert_logger.warning(time_now)
 
-            for key, values in self.seen_values.iteritems():
-                if not values:
-                    if type(key) == tuple:
-                        # If we don't have any results, it could either be because of the absence of any baseline data
-                        # OR it may be because the composite key contained a non-primitive type.  Either way, give the
-                        # end-users a heads up to help them debug what might be going on.
-                        elastalert_logger.warning((
-                            'No results were found from all sub-aggregations.  This can either indicate that there is '
-                            'no baseline data OR that a non-primitive field was used in a composite key.'
-                        ))
-                    else:
-                        elastalert_logger.info('Found no values for %s' % (field))
-                    continue
-                self.seen_values[key] = list(set(values))
-                elastalert_logger.info('Found %s unique values for %s' % (len(set(values)), key))
+        update = self.terms_collection.initialize_ordered_bulk_op()
 
-    def flatten_aggregation_hierarchy(self, root, hierarchy_tuple=()):
-        """ For nested aggregations, the results come back in the following format:
-            {
-            "aggregations" : {
-                "filtered" : {
-                  "doc_count" : 37,
-                  "values" : {
-                    "doc_count_error_upper_bound" : 0,
-                    "sum_other_doc_count" : 0,
-                    "buckets" : [ {
-                      "key" : "1.1.1.1", # IP address (root)
-                      "doc_count" : 13,
-                      "values" : {
-                        "doc_count_error_upper_bound" : 0,
-                        "sum_other_doc_count" : 0,
-                        "buckets" : [ {
-                          "key" : "80",    # Port (sub-aggregation)
-                          "doc_count" : 3,
-                          "values" : {
-                            "doc_count_error_upper_bound" : 0,
-                            "sum_other_doc_count" : 0,
-                            "buckets" : [ {
-                              "key" : "ack",  # Reason (sub-aggregation, leaf-node)
-                              "doc_count" : 3
-                            }, {
-                              "key" : "syn",  # Reason (sub-aggregation, leaf-node)
-                              "doc_count" : 1
-                            } ]
-                          }
-                        }, {
-                          "key" : "82",    # Port (sub-aggregation)
-                          "doc_count" : 3,
-                          "values" : {
-                            "doc_count_error_upper_bound" : 0,
-                            "sum_other_doc_count" : 0,
-                            "buckets" : [ {
-                              "key" : "ack",  # Reason (sub-aggregation, leaf-node)
-                              "doc_count" : 3
-                            }, {
-                              "key" : "syn",  # Reason (sub-aggregation, leaf-node)
-                              "doc_count" : 3
-                            } ]
-                          }
-                        } ]
-                      }
-                    }, {
-                      "key" : "2.2.2.2", # IP address (root)
-                      "doc_count" : 4,
-                      "values" : {
-                        "doc_count_error_upper_bound" : 0,
-                        "sum_other_doc_count" : 0,
-                        "buckets" : [ {
-                          "key" : "443",    # Port (sub-aggregation)
-                          "doc_count" : 3,
-                          "values" : {
-                            "doc_count_error_upper_bound" : 0,
-                            "sum_other_doc_count" : 0,
-                            "buckets" : [ {
-                              "key" : "ack",  # Reason (sub-aggregation, leaf-node)
-                              "doc_count" : 3
-                            }, {
-                              "key" : "syn",  # Reason (sub-aggregation, leaf-node)
-                              "doc_count" : 3
-                            } ]
-                          }
-                        } ]
-                      }
-                    } ]
-                  }
-                }
-              }
-            }
+        for term in new_terms:
+            match = {'timestamp_field': self.rules['timestamp_field'], self.rules['timestamp_field']: timestamp,
+                     'watched_field': self.agg_key, 'watched_field_value': term}
+            self.add_match(match)
+            # add the new terms to the collection of known terms
+            update.insert({'rule': self.rules['name'], 'term': term, 'time': time_now})
 
-            Each level will either have more values and buckets, or it will be a leaf node
-            We'll ultimately return a flattened list with the hierarchies appended as strings,
-            e.g the above snippet would yield a list with:
+        for term in terms_list:
+            update.find({'rule': self.rules['name'], 'term': term}).update({'$set': {'time': time_now}})
 
-            [
-             ('1.1.1.1', '80', 'ack'),
-             ('1.1.1.1', '80', 'syn'),
-             ('1.1.1.1', '82', 'ack'),
-             ('1.1.1.1', '82', 'syn'),
-             ('2.2.2.2', '443', 'ack'),
-             ('2.2.2.2', '443', 'syn')
-            ]
+        update.execute()
 
-            A similar formatting will be performed in the add_data method and used as the basis for comparison
+        self.clean_sonar_collection(start_window)
 
-        """
-        results = []
-        # There are more aggregation hierarchies left.  Traverse them.
-        if 'values' in root:
-            results += self.flatten_aggregation_hierarchy(root['values']['buckets'], hierarchy_tuple + (root['key'],))
-        else:
-            # We've gotten to a sub-aggregation, which may have further sub-aggregations
-            # See if we need to traverse further
-            for node in root:
-                if 'values' in node:
-                    results += self.flatten_aggregation_hierarchy(node, hierarchy_tuple)
-                else:
-                    results.append(hierarchy_tuple + (node['key'],))
+    def check_initialization(self, query, rule, timestamp_field, starttime, endtime, index):
+        if self.initialized == False:
+            start_window = self.rules['starttime'] - datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
+            self.terms_collection.remove({'rule': self.rules['name'], 'time': {'$lt': start_window}})
 
-        return results
+            step = datetime.timedelta(**self.rules.get('window_step_size', {'days': 1}))
+            elastalert_logger.warning('query = {}'.format(query))
+            query['aggs'] = self.rules['aggregation_query_element']
 
-    def add_data(self, data):
-        for document in data:
-            for field in self.fields:
-                value = ()
-                lookup_field = field
-                if type(field) == list:
-                    # For composite keys, make the lookup based on all fields
-                    # Make it a tuple since it can be hashed and used in dictionary lookups
-                    lookup_field = tuple(field)
-                    for sub_field in field:
-                        lookup_result = lookup_es_key(document, sub_field)
-                        if not lookup_result:
-                            value = None
-                            break
-                        value += (lookup_result,)
-                else:
-                    value = lookup_es_key(document, field)
-                if not value and self.rules.get('alert_on_missing_field'):
-                    document['missing_field'] = lookup_field
-                    self.add_match(copy.deepcopy(document))
-                elif value:
-                    if value not in self.seen_values[lookup_field]:
-                        document['new_field'] = lookup_field
-                        self.add_match(copy.deepcopy(document))
-                        self.seen_values[lookup_field].append(value)
+            # TODO break up run into smaller segments
 
-    def add_terms_data(self, terms):
-        # With terms query, len(self.fields) is always 1 and the 0'th entry is always a string
-        field = self.fields[0]
-        for timestamp, buckets in terms.iteritems():
-            for bucket in buckets:
-                if bucket['doc_count']:
-                    if bucket['key'] not in self.seen_values[field]:
-                        match = {field: bucket['key'],
-                                 self.rules['timestamp_field']: timestamp,
-                                 'new_field': field}
-                        self.add_match(match)
-                        self.seen_values[field].append(bucket['key'])
+            query['query']['bool']['must'].insert(0, {'range': {self.rules[timestamp_field]: {'gt': start_window,
+                                                                                 'lte': starttime}}})
+            aggregation_data = self.es.search(index=index, doc_type=rule.get('doc_type'), size=0,
+                                                          body=query, ignore_unavailable=True)
+            terms = [item['key'] for item in aggregation_data['hits']['aggregations'][self.rules['query_key']['buckets']]]
+            elastalert_logger.warning('initial_response = {}'.format(terms))
 
-    def is_five_or_above(self):
-        version = self.es.info()['version']['number']
-        return int(version[0]) >= 5
+
+
+    '''
+    def extend_query(self, base_query):
+        """nests the query inside another boolean query to only get documents on the blacklist"""
+        inner_query = base_query['query']
+        query = {"query": {"bool": {"must": [inner_query, {"bool": {"must_not":{ 'terms':{'aggs': }}}}]}}}
+        return query
+
+    def check_matches(self, timestamp, aggregation_data):
+        for item in aggregation_data['{}'.format(self.agg_key)]['buckets']:
+            match = {'timestamp_field': self.rules['timestamp_field'], self.rules['timestamp_field']: timestamp,
+                     'watched_field': self.agg_key, 'watched_field_value': item['key'], "doc_count": item['doc_count']}
+            self.add_match(match)
+    '''
+
+    def clean_sonar_collection(self, start_window):
+        self.terms_collection.remove({'rule': self.rules['name'], 'time': {'$lt': start_window}})

--- a/elastalert/rule_type_definitions/new_terms_rule.py
+++ b/elastalert/rule_type_definitions/new_terms_rule.py
@@ -1,12 +1,9 @@
 import datetime
 import ConfigParser
 
-import pymongo
-
 from elastalert.constants import DISPATCHER_CONF, NEW_TERM_DB, NEW_TERM_COLL
 from elastalert.rule_type_definitions.ruletypes import RuleType
-from elastalert.util import (add_raw_postfix, EAException, elastalert_logger, elasticsearch_client, format_index, get_index,
-lookup_es_key, ts_to_dt, ts_now, get_sonar_connection)
+from elastalert.util import (elasticsearch_client, get_sonar_connection)
 
 
 class NewTermsRule(RuleType):
@@ -25,14 +22,14 @@ class NewTermsRule(RuleType):
 
         self.sonar_con = get_sonar_connection(uri)
         self.terms_collection = self.sonar_con[NEW_TERM_DB][NEW_TERM_COLL]
-        elastalert_logger.warning('___________init New Terms RUle_______________')
+        self.initialized = True
 
-        if not list(self.terms_collection.find({'rule': self.rules['name'], 'time': {'$exists': False}}).limit(1)):
+        if not self.terms_collection.find_one({'rule': self.rules['name']}):
             self.terms_collection.insert_one({'rule': self.rules['name']})
 
-        self.es = elasticsearch_client(self.rules)
+        self.initialized = False  # TODO should happen each restart? If not move this line into if
 
-        self.initialized = False
+        self.es = elasticsearch_client(self.rules)
 
     def generate_aggregation_query(self, key):
         self.agg_key = key
@@ -43,18 +40,10 @@ class NewTermsRule(RuleType):
         for timestamp, payload_data in payload.iteritems():
             self.check_matches(timestamp, payload_data)
 
-    def check_matches(self, timestamp, aggregation_data):
+    def check_matches(self, timestamp, aggregation_data, add_match=True):
         terms_list = [item['key'] for item in aggregation_data['bucket_aggs']['buckets']]
-        elastalert_logger.warning('terms list = {}'.format(terms_list))
-        end_window = self.rules['starttime']
-        start_window = self.rules['starttime'] - datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
 
-        pipe = [{'$match': {'$and': [{'rule': self.rules['name']},
-                                     {'$or': [{'$and': [{'time': {'$lte': end_window}},
-                                                        {'time': {'$gte': start_window}}]},
-                                              {'time': {'$exists': False}}
-                                              ]}
-                                     ]}},
+        pipe = [{'$match': {'rule': self.rules['name']}},
                 {'$group': {'_id': '$rule', 'vals': {'$addToSet': "$term"}}},
                 {'$project': {
                     'new_terms': {'$filter': {'input': terms_list, 'as': 'value', 'cond': {'$not': {
@@ -66,29 +55,20 @@ class NewTermsRule(RuleType):
         except IndexError:
             new_terms = []
 
-        elastalert_logger.warning('new_terms = {}'.format(new_terms))
-        time_now = end_window + datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))/2
-
-        if new_terms or terms_list:
+        if new_terms:
             update = self.terms_collection.initialize_ordered_bulk_op()
 
             for term in new_terms:
-                match = {'timestamp_field': self.rules['timestamp_field'], self.rules['timestamp_field']: timestamp,
-                         'watched_field': self.agg_key, 'watched_field_value': term}
-                self.add_match(match)
+                if add_match:
+                    match = {'timestamp_field': self.rules['timestamp_field'], self.rules['timestamp_field']: timestamp,
+                             'watched_field': self.agg_key, 'watched_field_value': term}
+                    self.add_match(match)
                 # add the new terms to the collection of known terms
-                update.insert({'rule': self.rules['name'], 'term': term, 'time': time_now})
-
-            for term in terms_list:
-                update.find({'rule': self.rules['name'], 'term': term}).update({'$set': {'time': time_now}})
+                update.insert({'rule': self.rules['name'], 'term': term})
 
             update.execute()
 
-        self.clean_sonar_collection(start_window)
-
     def check_initialization(self):
-        start_window = self.rules['starttime'] - datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
-        self.terms_collection.remove({'rule': self.rules['name'], 'time': {'$lt': start_window}})
         if self.initialized:
             return True
         else:
@@ -97,43 +77,11 @@ class NewTermsRule(RuleType):
 
     def get_last_data_time(self, startime):
         start_window = startime - datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
-        last_data = self.terms_collection.find_one({'rule': self.rules['name'],
-                                                    'time': {'$gt': start_window}})  # .sort(['time', pymongo.DESCENDING])
-        elastalert_logger.warning('last_data = {}'.format(last_data))
-        if last_data:
-            return last_data['time']
-        else:
-            return start_window
+        return start_window
 
-    def run_initialization(self, query, rule, timestamp_field, starttime, endtime, index):
-
-            # step = datetime.timedelta(**self.rules.get('window_step_size', {'days': 1}))
-            elastalert_logger.warning('query = {}'.format(query))
-            query['aggs'] = self.rules['aggregation_query_element']
-
-            # TODO break up run into smaller segments
+    def run_initialization(self, query, rule, index):
 
             aggregation_data = self.es.search(index=index, doc_type=rule.get('doc_type'), size=0,
                                                           body=query, ignore_unavailable=True)
-            elastalert_logger.warning('aggregation_data = {}'.format(aggregation_data['aggregations'][self.rules['query_key']]))
-            terms = [item['key'] for item in aggregation_data['aggregations'][self.rules['query_key']['buckets']]]
-            elastalert_logger.warning('initial_response = {}'.format(terms))
+            self.check_matches(datetime.datetime.utcnow(), aggregation_data['aggregations'], add_match=False)
 
-
-
-    '''
-    def extend_query(self, base_query):
-        """nests the query inside another boolean query to only get documents on the blacklist"""
-        inner_query = base_query['query']
-        query = {"query": {"bool": {"must": [inner_query, {"bool": {"must_not":{ 'terms':{'aggs': }}}}]}}}
-        return query
-
-    def check_matches(self, timestamp, aggregation_data):
-        for item in aggregation_data['{}'.format(self.agg_key)]['buckets']:
-            match = {'timestamp_field': self.rules['timestamp_field'], self.rules['timestamp_field']: timestamp,
-                     'watched_field': self.agg_key, 'watched_field_value': item['key'], "doc_count": item['doc_count']}
-            self.add_match(match)
-    '''
-
-    def clean_sonar_collection(self, start_window):
-        self.terms_collection.remove({'rule': self.rules['name'], 'time': {'$lt': start_window}})


### PR DESCRIPTION
New terms rules now:
-Use a terms aggregation when retrieving data from ES
-Store the previously seen terms in sonar rather than in memory
-use an aggregation with $filter to match the terms from each run to the existing terms 