### PR TITLE
SES: Spike rule big data fix

### DIFF
--- a/elastalert/alerts.py
+++ b/elastalert/alerts.py
@@ -192,8 +192,15 @@ class SonarFormattedMatchString:
                 text += "{} events in timeframe. Maximum of {} expected.".format(self.match['num_hits'],
                                                                                    self.rule['num_events'])
         elif isinstance(self.rule['type'], SpikeRule):
-            text += "{} hits in spike. {} hits in previous window.".format(self.match['spike_count'],
-                                                                          self.match['reference_count'])
+            if self.rule.get('query_key'):
+                text += "{} hits in spike for value {} of query_key {}. {} hits in previous window.".format(
+                    self.match['spike_count'],
+                    self.rule['query_key'],
+                    self.match['key'],
+                    self.match['reference_count'])
+            else:
+                text += "{} hits in spike. {} hits in previous window.".format(self.match['spike_count'],
+                                                                              self.match['reference_count'])
         elif isinstance(self.rule['type'], CardinalityRule):
             if self.rule.get('query_key'):
                 text += "Cardinality of field {} for value {} of query key {} is {}. " \
@@ -232,12 +239,7 @@ class SyslogFormattedMatch:
     onwards to syslog in the appropriate format"""
     def __init__(self, rule, match, sonar_con, syslog_host, syslog_port, syslog_protocol, output_format,
                  vendor, product, version):
-        """
-        :param rule: The rule dictionary containing the parameters of the running rule
-        :param match: Information about what triggered this alert. Contents vary by rule type.
-        :param dispatch_config: config parser loaded from dispatcher.conf
-        :param sonar_con: Pymongo connection to sonar
-        """
+
         self.rule = rule
         self.match = match
         self.sonar_con = sonar_con
@@ -305,8 +307,14 @@ class SyslogFormattedMatch:
                 out_json.update({'frequency': self.match['num_hits'], 'threshold': self.rule['num_events']})
 
         elif isinstance(self.rule['type'], SpikeRule):
-            out_json.update({'spike_window_hits': self.match['spike_count'],
-                             'reference_window_hits': self.match['reference_count']})
+            if self.rule.get('query_key'):
+                out_json.update({'spike_window_hits': self.match['spike_count'],
+                                 'reference_window_hits': self.match['reference_count'],
+                                 'query_key': self.rule['query_key'],
+                                 'key_value': self.match['key']})
+            else:
+                out_json.update({'spike_window_hits': self.match['spike_count'],
+                                 'reference_window_hits': self.match['reference_count']})
 
         elif isinstance(self.rule['type'], CardinalityRule):
             if self.rule.get('query_key'):

--- a/elastalert/constants.py
+++ b/elastalert/constants.py
@@ -3,5 +3,5 @@ SYSLOG_DEFAULT_HOST = '127.0.0.1'
 SYSLOG_DEFAULT_PORT = 514
 SYSLOG_DEFAULT_PROTOCOL = 'udp'
 
-NEW_TERM_DB = 'test'
-NEW_TERM_COLL = 'test_new_terms'
+NEW_TERM_DB = 'lmrm__sonarg'
+NEW_TERM_COLL = 'lmrm__elastalert_new_terms_reference'

--- a/elastalert/constants.py
+++ b/elastalert/constants.py
@@ -2,3 +2,6 @@ DISPATCHER_CONF = '/opt/sonarfinder/sonarFinder/dispatcher.conf'
 SYSLOG_DEFAULT_HOST = '127.0.0.1'
 SYSLOG_DEFAULT_PORT = 514
 SYSLOG_DEFAULT_PROTOCOL = 'udp'
+
+NEW_TERM_DB = 'test'
+NEW_TERM_COLL = 'test_new_terms'

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -694,7 +694,6 @@ class ElastAlerter():
         :param end: The latest time to query.
         Returns True on success and False on failure.
         """
-        elastalert_logger.warning('_______________running_query____________')
         if start is None:
             start = self.get_index_start(get_index_util(rule))
         if end is None:
@@ -957,7 +956,6 @@ class ElastAlerter():
         :param endtime: The latest timestamp to query.
         :return: The number of matches that the rule produced.
         """
-        elastalert_logger.warning('_____________Running_rule__________________')
         run_start = time.time()
 
         self.current_es = elasticsearch_client(rule)

--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -713,7 +713,7 @@ class ElastAlerter():
                 old_len = len(data)
                 data = self.remove_duplicate_events(data, rule)
                 self.num_dupes += old_len - len(data)
-
+        elastalert_logger.warning('data = {}'.format(data))
         # There was an exception while querying
         if data is None:
             return False

--- a/elastalert/rule_type_definitions/new_terms_rule.py
+++ b/elastalert/rule_type_definitions/new_terms_rule.py
@@ -1,10 +1,10 @@
-import copy
 import datetime
-import sys
+import ConfigParser
 
+from elastalert.constants import DISPATCHER_CONF, NEW_TERM_DB, NEW_TERM_COLL
 from elastalert.rule_type_definitions.ruletypes import RuleType
 from elastalert.util import (add_raw_postfix, EAException, elastalert_logger, elasticsearch_client, format_index, get_index,
-                             lookup_es_key, ts_to_dt, ts_now)
+lookup_es_key, ts_to_dt, ts_now, get_sonar_connection)
 
 
 class NewTermsRule(RuleType):
@@ -12,272 +12,105 @@ class NewTermsRule(RuleType):
 
     def __init__(self, rule, args=None):
         super(NewTermsRule, self).__init__(rule, args)
-        self.seen_values = {}
-        # Allow the use of query_key or fields
-        if 'fields' not in self.rules:
-            if 'query_key' not in self.rules:
-                raise EAException("fields or query_key must be specified")
-            self.fields = self.rules['query_key']
-        else:
-            self.fields = self.rules['fields']
-        if not self.fields:
-            raise EAException("fields must not be an empty list")
-        if type(self.fields) != list:
-            self.fields = [self.fields]
-        if self.rules.get('use_terms_query') and \
-                (len(self.fields) != 1 or (len(self.fields) == 1 and type(self.fields[0]) == list)):
-            raise EAException("use_terms_query can only be used with a single non-composite field")
-        if self.rules.get('use_terms_query'):
-            if [self.rules['query_key']] != self.fields:
-                raise EAException('If use_terms_query is specified, you cannot specify different query_key and fields')
-            if not self.rules.get('query_key').endswith('.keyword') and not self.rules.get('query_key').endswith('.raw'):
-                if self.rules.get('use_keyword_postfix', True):
-                    elastalert_logger.warn('Warning: If query_key is a non-keyword field, you must set '
-                                           'use_keyword_postfix to false, or add .keyword/.raw to your query_key.')
-        try:
-            self.get_all_terms(args)
-        except Exception as e:
-            # Refuse to start if we cannot get existing terms
-            raise EAException('Error searching for existing terms: %s' % (repr(e))), None, sys.exc_info()[2]
+        self.rules['use_run_every_query_size'] = True
+        self.rules['realert'] = datetime.timedelta(0)
+        self.agg_key = None
+        self.rules['aggregation_query_element'] = self.generate_aggregation_query(self.rules['query_key'])
 
-    def get_all_terms(self, args):
-        """ Performs a terms aggregation for each field to get every existing term. """
+        conf = ConfigParser.ConfigParser()
+        conf.read(DISPATCHER_CONF)
+        uri = conf.get('dispatch', 'sonarw_uri')
+
+        self.sonar_con = get_sonar_connection(uri)
+        self.terms_collection = self.sonar_con[NEW_TERM_DB][NEW_TERM_COLL]
+        elastalert_logger.warning('___________init New Terms RUle_______________')
+
+        self.terms_collection.insert_one({'rule': self.rules['name'],
+                                          'term': 'lmrm__SONAR_ALERT_RULE_ACTIVE__',
+                                          'time': datetime.datetime.utcnow()})
+
         self.es = elasticsearch_client(self.rules)
-        window_size = datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
-        field_name = {"field": "", "size": 2147483647}  # Integer.MAX_VALUE
-        query_template = {"aggs": {"values": {"terms": field_name}}}
-        if args and hasattr(args, 'start') and args.start:
-            end = ts_to_dt(args.start)
-        elif 'start_date' in self.rules:
-            end = ts_to_dt(self.rules['start_date'])
-        else:
-            end = ts_now()
-        start = end - window_size
-        step = datetime.timedelta(**self.rules.get('window_step_size', {'days': 1}))
 
-        for field in self.fields:
-            tmp_start = start
-            tmp_end = min(start + step, end)
+        self.initialized = False
 
-            time_filter = {self.rules['timestamp_field']: {'lt': self.rules['dt_to_ts'](tmp_end), 'gte': self.rules['dt_to_ts'](tmp_start)}}
-            query_template['filter'] = {'bool': {'must': [{'range': time_filter}]}}
-            query = {'aggs': {'filtered': query_template}}
+    def generate_aggregation_query(self, key):
+        self.agg_key = key
+        agg_query = {'{}'.format(key): {'terms': {'field': key}}}
+        return agg_query
 
-            if 'filter' in self.rules:
-                for item in self.rules['filter']:
-                    query_template['filter']['bool']['must'].append(item)
+    def add_aggregation_data(self, payload):
+        for timestamp, payload_data in payload.iteritems():
+            self.check_matches(timestamp, payload_data)
 
-            # For composite keys, we will need to perform sub-aggregations
-            if type(field) == list:
-                self.seen_values.setdefault(tuple(field), [])
-                level = query_template['aggs']
-                # Iterate on each part of the composite key and add a sub aggs clause to the elastic search query
-                for i, sub_field in enumerate(field):
-                    if self.rules.get('use_keyword_postfix', True):
-                        level['values']['terms']['field'] = add_raw_postfix(sub_field, self.is_five_or_above())
-                    else:
-                        level['values']['terms']['field'] = sub_field
-                    if i < len(field) - 1:
-                        # If we have more fields after the current one, then set up the next nested structure
-                        level['values']['aggs'] = {'values': {'terms': copy.deepcopy(field_name)}}
-                        level = level['values']['aggs']
-            else:
-                self.seen_values.setdefault(field, [])
-                # For non-composite keys, only a single agg is needed
-                if self.rules.get('use_keyword_postfix', True):
-                    field_name['field'] = add_raw_postfix(field, self.is_five_or_above())
-                else:
-                    field_name['field'] = field
+    def check_matches(self, timestamp, aggregation_data):
+        terms_list = [item['key'] for item in aggregation_data['bucket_aggs']['buckets']]
+        elastalert_logger.warning('terms list = {}'.format(terms_list))
+        end_window = self.rules['starttime']
+        start_window = self.rules['starttime'] - datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
+        elastalert_logger.warning('startwindow: {}  endwindow: {}'.format(start_window, end_window))
+        pipe = [{'$match': {'$and': [{'rule': self.rules['name']},
+                                     {'time': {'$lte': end_window}},
+                                     {'time': {'$gte': start_window}}]}},
+                {'$group': {'_id': '$rule', 'vals': {'$addToSet': "$term"}}},
+                {'$project': {
+                    'new_terms': {'$filter': {'input': terms_list, 'as': 'value', 'cond': {'$not': {
+                        '$setIsSubset': [['$$value'], '$vals']}
+                    }}}}}]
 
-            # Query the entire time range in small chunks
-            while tmp_start < end:
-                if self.rules.get('use_strftime_index'):
-                    index = format_index(get_index(self.rules), tmp_start, tmp_end)
-                else:
-                    index = get_index(self.rules)
-                res = self.es.search(body=query, index=index, ignore_unavailable=True, timeout='50s')
-                if 'aggregations' in res:
-                    buckets = res['aggregations']['filtered']['values']['buckets']
-                    if type(field) == list:
-                        # For composite keys, make the lookup based on all fields
-                        # Make it a tuple since it can be hashed and used in dictionary lookups
-                        for bucket in buckets:
-                            # We need to walk down the hierarchy and obtain the value at each level
-                            self.seen_values[tuple(field)] += self.flatten_aggregation_hierarchy(bucket)
-                    else:
-                        keys = [bucket['key'] for bucket in buckets]
-                        self.seen_values[field] += keys
-                else:
-                    if type(field) == list:
-                        self.seen_values.setdefault(tuple(field), [])
-                    else:
-                        self.seen_values.setdefault(field, [])
-                if tmp_start == tmp_end:
-                    break
-                tmp_start = tmp_end
-                tmp_end = min(tmp_start + step, end)
-                time_filter[self.rules['timestamp_field']] = {'lt': self.rules['dt_to_ts'](tmp_end),
-                                                              'gte': self.rules['dt_to_ts'](tmp_start)}
+        new_terms = list(self.terms_collection.aggregate(pipe))[0]['new_terms']
+        elastalert_logger.warning('new_terms = {}'.format(new_terms))
+        time_now = end_window + datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))/2
+        elastalert_logger.warning(time_now)
 
-            for key, values in self.seen_values.iteritems():
-                if not values:
-                    if type(key) == tuple:
-                        # If we don't have any results, it could either be because of the absence of any baseline data
-                        # OR it may be because the composite key contained a non-primitive type.  Either way, give the
-                        # end-users a heads up to help them debug what might be going on.
-                        elastalert_logger.warning((
-                            'No results were found from all sub-aggregations.  This can either indicate that there is '
-                            'no baseline data OR that a non-primitive field was used in a composite key.'
-                        ))
-                    else:
-                        elastalert_logger.info('Found no values for %s' % (field))
-                    continue
-                self.seen_values[key] = list(set(values))
-                elastalert_logger.info('Found %s unique values for %s' % (len(set(values)), key))
+        update = self.terms_collection.initialize_ordered_bulk_op()
 
-    def flatten_aggregation_hierarchy(self, root, hierarchy_tuple=()):
-        """ For nested aggregations, the results come back in the following format:
-            {
-            "aggregations" : {
-                "filtered" : {
-                  "doc_count" : 37,
-                  "values" : {
-                    "doc_count_error_upper_bound" : 0,
-                    "sum_other_doc_count" : 0,
-                    "buckets" : [ {
-                      "key" : "1.1.1.1", # IP address (root)
-                      "doc_count" : 13,
-                      "values" : {
-                        "doc_count_error_upper_bound" : 0,
-                        "sum_other_doc_count" : 0,
-                        "buckets" : [ {
-                          "key" : "80",    # Port (sub-aggregation)
-                          "doc_count" : 3,
-                          "values" : {
-                            "doc_count_error_upper_bound" : 0,
-                            "sum_other_doc_count" : 0,
-                            "buckets" : [ {
-                              "key" : "ack",  # Reason (sub-aggregation, leaf-node)
-                              "doc_count" : 3
-                            }, {
-                              "key" : "syn",  # Reason (sub-aggregation, leaf-node)
-                              "doc_count" : 1
-                            } ]
-                          }
-                        }, {
-                          "key" : "82",    # Port (sub-aggregation)
-                          "doc_count" : 3,
-                          "values" : {
-                            "doc_count_error_upper_bound" : 0,
-                            "sum_other_doc_count" : 0,
-                            "buckets" : [ {
-                              "key" : "ack",  # Reason (sub-aggregation, leaf-node)
-                              "doc_count" : 3
-                            }, {
-                              "key" : "syn",  # Reason (sub-aggregation, leaf-node)
-                              "doc_count" : 3
-                            } ]
-                          }
-                        } ]
-                      }
-                    }, {
-                      "key" : "2.2.2.2", # IP address (root)
-                      "doc_count" : 4,
-                      "values" : {
-                        "doc_count_error_upper_bound" : 0,
-                        "sum_other_doc_count" : 0,
-                        "buckets" : [ {
-                          "key" : "443",    # Port (sub-aggregation)
-                          "doc_count" : 3,
-                          "values" : {
-                            "doc_count_error_upper_bound" : 0,
-                            "sum_other_doc_count" : 0,
-                            "buckets" : [ {
-                              "key" : "ack",  # Reason (sub-aggregation, leaf-node)
-                              "doc_count" : 3
-                            }, {
-                              "key" : "syn",  # Reason (sub-aggregation, leaf-node)
-                              "doc_count" : 3
-                            } ]
-                          }
-                        } ]
-                      }
-                    } ]
-                  }
-                }
-              }
-            }
+        for term in new_terms:
+            match = {'timestamp_field': self.rules['timestamp_field'], self.rules['timestamp_field']: timestamp,
+                     'watched_field': self.agg_key, 'watched_field_value': term}
+            self.add_match(match)
+            # add the new terms to the collection of known terms
+            update.insert({'rule': self.rules['name'], 'term': term, 'time': time_now})
 
-            Each level will either have more values and buckets, or it will be a leaf node
-            We'll ultimately return a flattened list with the hierarchies appended as strings,
-            e.g the above snippet would yield a list with:
+        for term in terms_list:
+            update.find({'rule': self.rules['name'], 'term': term}).update({'$set': {'time': time_now}})
 
-            [
-             ('1.1.1.1', '80', 'ack'),
-             ('1.1.1.1', '80', 'syn'),
-             ('1.1.1.1', '82', 'ack'),
-             ('1.1.1.1', '82', 'syn'),
-             ('2.2.2.2', '443', 'ack'),
-             ('2.2.2.2', '443', 'syn')
-            ]
+        update.execute()
 
-            A similar formatting will be performed in the add_data method and used as the basis for comparison
+        self.clean_sonar_collection(start_window)
 
-        """
-        results = []
-        # There are more aggregation hierarchies left.  Traverse them.
-        if 'values' in root:
-            results += self.flatten_aggregation_hierarchy(root['values']['buckets'], hierarchy_tuple + (root['key'],))
-        else:
-            # We've gotten to a sub-aggregation, which may have further sub-aggregations
-            # See if we need to traverse further
-            for node in root:
-                if 'values' in node:
-                    results += self.flatten_aggregation_hierarchy(node, hierarchy_tuple)
-                else:
-                    results.append(hierarchy_tuple + (node['key'],))
+    def check_initialization(self, query, rule, timestamp_field, starttime, endtime, index):
+        if self.initialized == False:
+            start_window = self.rules['starttime'] - datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
+            self.terms_collection.remove({'rule': self.rules['name'], 'time': {'$lt': start_window}})
 
-        return results
+            step = datetime.timedelta(**self.rules.get('window_step_size', {'days': 1}))
+            elastalert_logger.warning('query = {}'.format(query))
+            query['aggs'] = self.rules['aggregation_query_element']
 
-    def add_data(self, data):
-        for document in data:
-            for field in self.fields:
-                value = ()
-                lookup_field = field
-                if type(field) == list:
-                    # For composite keys, make the lookup based on all fields
-                    # Make it a tuple since it can be hashed and used in dictionary lookups
-                    lookup_field = tuple(field)
-                    for sub_field in field:
-                        lookup_result = lookup_es_key(document, sub_field)
-                        if not lookup_result:
-                            value = None
-                            break
-                        value += (lookup_result,)
-                else:
-                    value = lookup_es_key(document, field)
-                if not value and self.rules.get('alert_on_missing_field'):
-                    document['missing_field'] = lookup_field
-                    self.add_match(copy.deepcopy(document))
-                elif value:
-                    if value not in self.seen_values[lookup_field]:
-                        document['new_field'] = lookup_field
-                        self.add_match(copy.deepcopy(document))
-                        self.seen_values[lookup_field].append(value)
+            # TODO break up run into smaller segments
 
-    def add_terms_data(self, terms):
-        # With terms query, len(self.fields) is always 1 and the 0'th entry is always a string
-        field = self.fields[0]
-        for timestamp, buckets in terms.iteritems():
-            for bucket in buckets:
-                if bucket['doc_count']:
-                    if bucket['key'] not in self.seen_values[field]:
-                        match = {field: bucket['key'],
-                                 self.rules['timestamp_field']: timestamp,
-                                 'new_field': field}
-                        self.add_match(match)
-                        self.seen_values[field].append(bucket['key'])
+            query['query']['bool']['must'].insert(0, {'range': {self.rules[timestamp_field]: {'gt': start_window,
+                                                                                 'lte': starttime}}})
+            aggregation_data = self.es.search(index=index, doc_type=rule.get('doc_type'), size=0,
+                                                          body=query, ignore_unavailable=True)
+            terms = [item['key'] for item in aggregation_data['hits']['aggregations'][self.rules['query_key']['buckets']]]
+            elastalert_logger.warning('initial_response = {}'.format(terms))
 
-    def is_five_or_above(self):
-        version = self.es.info()['version']['number']
-        return int(version[0]) >= 5
+
+
+    '''
+    def extend_query(self, base_query):
+        """nests the query inside another boolean query to only get documents on the blacklist"""
+        inner_query = base_query['query']
+        query = {"query": {"bool": {"must": [inner_query, {"bool": {"must_not":{ 'terms':{'aggs': }}}}]}}}
+        return query
+
+    def check_matches(self, timestamp, aggregation_data):
+        for item in aggregation_data['{}'.format(self.agg_key)]['buckets']:
+            match = {'timestamp_field': self.rules['timestamp_field'], self.rules['timestamp_field']: timestamp,
+                     'watched_field': self.agg_key, 'watched_field_value': item['key'], "doc_count": item['doc_count']}
+            self.add_match(match)
+    '''
+
+    def clean_sonar_collection(self, start_window):
+        self.terms_collection.remove({'rule': self.rules['name'], 'time': {'$lt': start_window}})

--- a/elastalert/rule_type_definitions/new_terms_rule.py
+++ b/elastalert/rule_type_definitions/new_terms_rule.py
@@ -1,12 +1,9 @@
 import datetime
 import ConfigParser
 
-import pymongo
-
 from elastalert.constants import DISPATCHER_CONF, NEW_TERM_DB, NEW_TERM_COLL
 from elastalert.rule_type_definitions.ruletypes import RuleType
-from elastalert.util import (add_raw_postfix, EAException, elastalert_logger, elasticsearch_client, format_index, get_index,
-lookup_es_key, ts_to_dt, ts_now, get_sonar_connection)
+from elastalert.util import (elasticsearch_client, get_sonar_connection)
 
 
 class NewTermsRule(RuleType):
@@ -25,14 +22,14 @@ class NewTermsRule(RuleType):
 
         self.sonar_con = get_sonar_connection(uri)
         self.terms_collection = self.sonar_con[NEW_TERM_DB][NEW_TERM_COLL]
-        elastalert_logger.warning('___________init New Terms RUle_______________')
+        self.initialized = True
 
-        if not list(self.terms_collection.find({'rule': self.rules['name'], 'time': {'$exists': False}}).limit(1)):
+        if not self.terms_collection.find_one({'rule': self.rules['name']}):
             self.terms_collection.insert_one({'rule': self.rules['name']})
 
-        self.es = elasticsearch_client(self.rules)
+        self.initialized = False  # TODO should happen each restart? If not move this line into if
 
-        self.initialized = False
+        self.es = elasticsearch_client(self.rules)
 
     def generate_aggregation_query(self, key):
         self.agg_key = key
@@ -43,18 +40,10 @@ class NewTermsRule(RuleType):
         for timestamp, payload_data in payload.iteritems():
             self.check_matches(timestamp, payload_data)
 
-    def check_matches(self, timestamp, aggregation_data):
+    def check_matches(self, timestamp, aggregation_data, add_match=True):
         terms_list = [item['key'] for item in aggregation_data['bucket_aggs']['buckets']]
-        elastalert_logger.warning('terms list = {}'.format(terms_list))
-        end_window = self.rules['starttime']
-        start_window = self.rules['starttime'] - datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
 
-        pipe = [{'$match': {'$and': [{'rule': self.rules['name']},
-                                     {'$or': [{'$and': [{'time': {'$lte': end_window}},
-                                                        {'time': {'$gte': start_window}}]},
-                                              {'time': {'$exists': False}}
-                                              ]}
-                                     ]}},
+        pipe = [{'$match': {'rule': self.rules['name']}},
                 {'$group': {'_id': '$rule', 'vals': {'$addToSet': "$term"}}},
                 {'$project': {
                     'new_terms': {'$filter': {'input': terms_list, 'as': 'value', 'cond': {'$not': {
@@ -66,29 +55,20 @@ class NewTermsRule(RuleType):
         except IndexError:
             new_terms = []
 
-        elastalert_logger.warning('new_terms = {}'.format(new_terms))
-        time_now = end_window + datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))/2
-
-        if new_terms or terms_list:
+        if new_terms:
             update = self.terms_collection.initialize_ordered_bulk_op()
 
             for term in new_terms:
-                match = {'timestamp_field': self.rules['timestamp_field'], self.rules['timestamp_field']: timestamp,
-                         'watched_field': self.agg_key, 'watched_field_value': term}
-                self.add_match(match)
+                if add_match:
+                    match = {'timestamp_field': self.rules['timestamp_field'], self.rules['timestamp_field']: timestamp,
+                             'watched_field': self.agg_key, 'watched_field_value': term}
+                    self.add_match(match)
                 # add the new terms to the collection of known terms
-                update.insert({'rule': self.rules['name'], 'term': term, 'time': time_now})
-
-            for term in terms_list:
-                update.find({'rule': self.rules['name'], 'term': term}).update({'$set': {'time': time_now}})
+                update.insert({'rule': self.rules['name'], 'term': term})
 
             update.execute()
 
-        self.clean_sonar_collection(start_window)
-
     def check_initialization(self):
-        start_window = self.rules['starttime'] - datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
-        self.terms_collection.remove({'rule': self.rules['name'], 'time': {'$lt': start_window}})
         if self.initialized:
             return True
         else:
@@ -97,43 +77,11 @@ class NewTermsRule(RuleType):
 
     def get_last_data_time(self, startime):
         start_window = startime - datetime.timedelta(**self.rules.get('terms_window_size', {'days': 30}))
-        last_data = self.terms_collection.find_one({'rule': self.rules['name'],
-                                                    'time': {'$gt': start_window}})  # .sort(['time', pymongo.DESCENDING])
-        elastalert_logger.warning('last_data = {}'.format(last_data))
-        if last_data:
-            return last_data['time']
-        else:
-            return start_window
+        return start_window
 
-    def run_initialization(self, query, rule, timestamp_field, starttime, endtime, index):
-
-            # step = datetime.timedelta(**self.rules.get('window_step_size', {'days': 1}))
-            elastalert_logger.warning('query = {}'.format(query))
-            query['aggs'] = self.rules['aggregation_query_element']
-
-            # TODO break up run into smaller segments
+    def run_initialization(self, query, rule, index):
 
             aggregation_data = self.es.search(index=index, doc_type=rule.get('doc_type'), size=0,
                                                           body=query, ignore_unavailable=True)
-            elastalert_logger.warning('aggregation_data = {}'.format(aggregation_data['aggregations'][self.rules['query_key']]))
-            terms = [item['key'] for item in aggregation_data['aggregations'][self.rules['query_key']['buckets']]]
-            elastalert_logger.warning('initial_response = {}'.format(terms))
+            self.check_matches(datetime.datetime.utcnow(), aggregation_data['aggregations'], add_match=False)
 
-
-
-    '''
-    def extend_query(self, base_query):
-        """nests the query inside another boolean query to only get documents on the blacklist"""
-        inner_query = base_query['query']
-        query = {"query": {"bool": {"must": [inner_query, {"bool": {"must_not":{ 'terms':{'aggs': }}}}]}}}
-        return query
-
-    def check_matches(self, timestamp, aggregation_data):
-        for item in aggregation_data['{}'.format(self.agg_key)]['buckets']:
-            match = {'timestamp_field': self.rules['timestamp_field'], self.rules['timestamp_field']: timestamp,
-                     'watched_field': self.agg_key, 'watched_field_value': item['key'], "doc_count": item['doc_count']}
-            self.add_match(match)
-    '''
-
-    def clean_sonar_collection(self, start_window):
-        self.terms_collection.remove({'rule': self.rules['name'], 'time': {'$lt': start_window}})

--- a/elastalert/rule_type_definitions/spike_rule.py
+++ b/elastalert/rule_type_definitions/spike_rule.py
@@ -1,5 +1,6 @@
 from elastalert.rule_type_definitions.ruletypes import RuleType, EventWindow
 from elastalert.util import new_get_event_ts, EAException, hashable, lookup_es_key, elastalert_logger, pretty_ts
+from elastalert.util import (elasticsearch_client, get_sonar_connection)
 
 
 class SpikeRule(RuleType):
@@ -8,6 +9,19 @@ class SpikeRule(RuleType):
 
     def __init__(self, *args):
         super(SpikeRule, self).__init__(*args)
+        self.rules['aggregation_query_element'] = self.generate_aggregation_query()
+
+        self.es = elasticsearch_client(self.rules)
+
+    def generate_aggregation_query(self):
+        if self.rules.get('query_key'):
+            agg_query = {'{}'.format(key): {'terms': {'field': self.rules['query_key']}}}
+        return agg_query
+
+
+
+
+'''
         self.timeframe = self.rules['timeframe']
 
         self.ref_windows = {}
@@ -172,3 +186,4 @@ class SpikeRule(RuleType):
             if qk != 'all':
                 placeholder.update({self.rules['query_key']: qk})
             self.handle_event(placeholder, 0, qk)
+'''

--- a/elastalert/rule_type_definitions/spike_rule.py
+++ b/elastalert/rule_type_definitions/spike_rule.py
@@ -9,181 +9,42 @@ class SpikeRule(RuleType):
 
     def __init__(self, *args):
         super(SpikeRule, self).__init__(*args)
-        self.rules['aggregation_query_element'] = self.generate_aggregation_query()
+        elastalert_logger.warning('______________Spike_rule_init_________________')
+        if self.rules.get(['query_key']):
+            self.rules['use_count_query'] = False
+            self.rules['aggregation_query_element'] = True
+        else:
+            self.rules['use_count_query'] = True
+            self.rules['aggregation_query_element'] = False
 
         self.es = elasticsearch_client(self.rules)
 
     def generate_aggregation_query(self):
-        if self.rules.get('query_key'):
-            agg_query = {'{}'.format(key): {'terms': {'field': self.rules['query_key']}}}
+        agg_query = {'{}'.format(self.rules['query_key']): {'terms': {'field': self.rules['query_key']}}}
         return agg_query
 
 
-
-
 '''
-        self.timeframe = self.rules['timeframe']
-
-        self.ref_windows = {}
-        self.cur_windows = {}
-
-        self.ts_field = self.rules.get('timestamp_field', '@timestamp')
-        self.get_ts = new_get_event_ts(self.ts_field)
-        self.first_event = {}
-        self.skip_checks = {}
-
-        self.field_value = self.rules.get('field_value')
-
-        self.ref_window_filled_once = False
-
     def add_count_data(self, data):
         """ Add count data to the rule. Data should be of the form {ts: count}. """
+        elastalert_logger.warning('adding count data {}'.format(data))
         if len(data) > 1:
             raise EAException('add_count_data can only accept one count at a time')
         for ts, count in data.iteritems():
             self.handle_event({self.ts_field: ts}, count, 'all')
 
-    def add_terms_data(self, terms):
-        for timestamp, buckets in terms.iteritems():
-            for bucket in buckets:
-                count = bucket['doc_count']
-                event = {self.ts_field: timestamp,
-                         self.rules['query_key']: bucket['key']}
-                key = bucket['key']
-                self.handle_event(event, count, key)
+    def add_aggregation_data(self, payload):
+        elastalert_logger.warning('adding agg data {}'.format(payload))
+        for timestamp, payload_data in payload.iteritems():
+            self.check_matches(timestamp, payload_data)
 
-    def add_data(self, data):
-        for event in data:
-            qk = self.rules.get('query_key', 'all')
-            if qk != 'all':
-                qk = hashable(lookup_es_key(event, qk))
-                if qk is None:
-                    qk = 'other'
-            if self.field_value is not None:
-                if self.field_value in event:
-                    count = lookup_es_key(event, self.field_value)
-                    if count is not None:
-                        try:
-                            count = int(count)
-                        except ValueError:
-                            elastalert_logger.warn('{} is not a number: {}'.format(self.field_value, count))
-                        else:
-                            self.handle_event(event, count, qk)
-            else:
-                self.handle_event(event, 1, qk)
+    def check_matches(self):
+        pass
+        # TODO check that reference is above ref threshold
+        # TODO check that match is above match threshold
+        # TODO if spike up check that match > 3xreference
+        # TODO if spike down check that matchX3 < reference
 
-    def clear_windows(self, qk, event):
-        # Reset the state and prevent alerts until windows filled again
-        self.ref_windows[qk].clear()
-        self.first_event.pop(qk)
-        self.skip_checks[qk] = lookup_es_key(event, self.ts_field) + self.rules['timeframe'] * 2
-
-    def handle_event(self, event, count, qk='all'):
-        self.first_event.setdefault(qk, event)
-
-        self.ref_windows.setdefault(qk, EventWindow(self.timeframe, getTimestamp=self.get_ts))
-        self.cur_windows.setdefault(qk, EventWindow(self.timeframe, self.ref_windows[qk].append, self.get_ts))
-
-        self.cur_windows[qk].append((event, count))
-
-        # Don't alert if ref window has not yet been filled for this key AND
-        if lookup_es_key(event, self.ts_field) - self.first_event[qk][self.ts_field] < self.rules['timeframe'] * 2:
-            # ElastAlert has not been running long enough for any alerts OR
-            if not self.ref_window_filled_once:
-                return
-            # This rule is not using alert_on_new_data (with query_key) OR
-            if not (self.rules.get('query_key') and self.rules.get('alert_on_new_data')):
-                return
-            # An alert for this qk has recently fired
-            if qk in self.skip_checks and lookup_es_key(event, self.ts_field) < self.skip_checks[qk]:
-                return
-        else:
-            self.ref_window_filled_once = True
-
-        if self.field_value is not None:
-            if self.find_matches(self.ref_windows[qk].mean(), self.cur_windows[qk].mean()):
-                # skip over placeholder events
-                for match, count in self.cur_windows[qk].data:
-                    if "placeholder" not in match:
-                        break
-                self.add_match(match, qk)
-                self.clear_windows(qk, match)
-        else:
-            if self.find_matches(self.ref_windows[qk].count(), self.cur_windows[qk].count()):
-                # skip over placeholder events which have count=0
-                for match, count in self.cur_windows[qk].data:
-                    if count:
-                        break
-
-                self.add_match(match, qk)
-                self.clear_windows(qk, match)
-
-    def add_match(self, match, qk):
-        extra_info = {}
-        if self.field_value is None:
-            spike_count = self.cur_windows[qk].count()
-            reference_count = self.ref_windows[qk].count()
-        else:
-            spike_count = self.cur_windows[qk].mean()
-            reference_count = self.ref_windows[qk].mean()
-        extra_info = {'spike_count': spike_count,
-                      'reference_count': reference_count}
-
-        match = dict(match.items() + extra_info.items())
-
-        super(SpikeRule, self).add_match(match)
-
-    def find_matches(self, ref, cur):
-        """ Determines if an event spike or dip happening. """
-        # Apply threshold limits
-        if self.field_value is None:
-            if (cur < self.rules.get('threshold_cur', 0) or
-                    ref < self.rules.get('threshold_ref', 0)):
-                return False
-        elif ref is None or ref == 0 or cur is None or cur == 0:
-            return False
-
-        spike_up, spike_down = False, False
-        if cur <= ref / self.rules['spike_height']:
-            spike_down = True
-        if cur >= ref * self.rules['spike_height']:
-            spike_up = True
-
-        if (self.rules['spike_type'] in ['both', 'up'] and spike_up) or \
-           (self.rules['spike_type'] in ['both', 'down'] and spike_down):
-            return True
-        return False
-
-    def get_match_str(self, match):
-        if self.field_value is None:
-            message = 'An abnormal number (%d) of events occurred around %s.\n' % (
-                match['spike_count'],
-                pretty_ts(match[self.rules['timestamp_field']], self.rules.get('use_local_time'))
-            )
-            message += 'Preceding that time, there were only %d events within %s\n\n' % (match['reference_count'], self.rules['timeframe'])
-        else:
-            message = 'An abnormal average value (%.2f) of field \'%s\' occurred around %s.\n' % (
-                match['spike_count'],
-                self.field_value,
-                pretty_ts(match[self.rules['timestamp_field']],
-                          self.rules.get('use_local_time'))
-            )
-            message += 'Preceding that time, the field had an average value of (%.2f) within %s\n\n' % (
-                match['reference_count'], self.rules['timeframe'])
-        return message
-
-    def garbage_collect(self, ts):
-        # Windows are sized according to their newest event
-        # This is a placeholder to accurately size windows in the absence of events
-        for qk in self.cur_windows.keys():
-            # If we havn't seen this key in a long time, forget it
-            if qk != 'all' and self.ref_windows[qk].count() == 0 and self.cur_windows[qk].count() == 0:
-                self.cur_windows.pop(qk)
-                self.ref_windows.pop(qk)
-                continue
-            placeholder = {self.ts_field: ts, "placeholder": True}
-            # The placeholder may trigger an alert, in which case, qk will be expected
-            if qk != 'all':
-                placeholder.update({self.rules['query_key']: qk})
-            self.handle_event(placeholder, 0, qk)
+    def query_reference_window(self):
+        pass
 '''


### PR DESCRIPTION
-Spike rule now uses two terms queries per run
-Should now work on the first run rather than just saving a reference on the first run.