### PR TITLE
Alexander/continuously running rule startup

### DIFF
--- a/elastalert/elastalert.py
+++ b/elastalert/elastalert.py
@@ -718,7 +718,6 @@ class ElastAlerter():
         :param end: The latest time to query.
         Returns True on success and False on failure.
         """
-        elastalert_logger.warning('_________running query____________')
         if start is None:
             start = self.get_index_start(get_index_util(rule))
         if end is None:
@@ -980,7 +979,6 @@ class ElastAlerter():
         :param endtime: The latest timestamp to query.
         :return: The number of matches that the rule produced.
         """
-        elastalert_logger.warning('___________running rule {}___________'.format(rule['name']))
         run_start = time.time()
 
         self.current_es = elasticsearch_client(rule)


### PR DESCRIPTION
-previously when restarting these types of rules would usually calculate a
segment size that ran a fraction of second into the future
resulting in the rule not executing until the second run of the rule