### PR TITLE
SES-442 More dependable way to add scripted fields to es queries

### DIFF
--- a/elastalert/saved_source.py
+++ b/elastalert/saved_source.py
@@ -38,7 +38,6 @@ class SavedSource:
 
             for item in scripts:
                 if item.get('scripted'):
-                    elastalert_logger.warning(item['script'])
                     scripted_fields[item['name']] = {"script": {"inline": item['script'], "lang": "sonar"}}
 
         except Exception as e:


### PR DESCRIPTION
Uses json library to parse saved_object_index_patterns rather than using ast.literal_eval(). This should work for a much wider range of cases.