### PR TITLE
SES: Fix reading sonar config

### DIFF
--- a/elastalert/constants.py
+++ b/elastalert/constants.py
@@ -1,3 +1,6 @@
+import os
+
+SONARK_CONF = os.environ.get('SONARK_CONFIG_PATH')
 DISPATCHER_CONF = '/opt/sonarfinder/sonarFinder/dispatcher.conf'
 SYSLOG_DEFAULT_HOST = '127.0.0.1'
 SYSLOG_DEFAULT_PORT = 514

--- a/elastalert/sonar_connection.py
+++ b/elastalert/sonar_connection.py
@@ -2,14 +2,15 @@ import os
 from elasticsearch import connection
 import yaml
 
+from constants import SONARK_CONF
+
 
 def getSonarConfig():
-    full_path = os.environ.get('SONARK_CONFIG_PATH')
-    if os.path.isfile(full_path):
-        return yaml.load(open(full_path))
+    if os.path.isfile(SONARK_CONF):
+        return yaml.load(open(SONARK_CONF))
     else:
         raise Exception(
-            "kibana.yml can't be found in the root directory of sonark. Ensure Sonark is installed properly.")
+            "kibana.yml can't be found in {}. Ensure Sonark is installed properly.".format(SONARK_CONF))
 
 
 class SonarConnectionUrllib3HttpConnection(connection.Urllib3HttpConnection):

--- a/elastalert/sonar_connection.py
+++ b/elastalert/sonar_connection.py
@@ -16,13 +16,13 @@ class SonarConnectionUrllib3HttpConnection(connection.Urllib3HttpConnection):
     def __init__(self, *args, **kwargs):
         super(SonarConnectionUrllib3HttpConnection, self).__init__(*args, **kwargs)
         self.headers.update({
-            'sonarg-user': getSonarConfig()['elasticsearch.customHeaders']['sonarg-user']
+            'sonarg-user': os.environ['elasticsearch.customHeaders.sonarg-user']
         })
 
 
 class SonarConnectionRequestsHttpConnection(connection.RequestsHttpConnection):
     def __init__(self, *args, **kwargs):
         kwargs['headers'] = {
-            'sonarg-user': getSonarConfig()['elasticsearch.customHeaders']['sonarg-user']
+            'sonarg-user': os.environ['elasticsearch.customHeaders.sonarg-user']
         }
         super(SonarConnectionRequestsHttpConnection, self).__init__(*args, **kwargs)

--- a/elastalert/sonar_connection.py
+++ b/elastalert/sonar_connection.py
@@ -4,7 +4,7 @@ import yaml
 
 
 def getSonarConfig():
-    full_path = os.path.join('../../../config', 'kibana.yml')
+    full_path = os.environ.get('SONARK_CONFIG_PATH')
     if os.path.isfile(full_path):
         return yaml.load(open(full_path))
     else:
@@ -16,13 +16,13 @@ class SonarConnectionUrllib3HttpConnection(connection.Urllib3HttpConnection):
     def __init__(self, *args, **kwargs):
         super(SonarConnectionUrllib3HttpConnection, self).__init__(*args, **kwargs)
         self.headers.update({
-            'sonarg-user': os.environ['elasticsearch.customHeaders.sonarg-user']
+            'sonarg-user': getSonarConfig()['elasticsearch.customHeaders']['sonarg-user']
         })
 
 
 class SonarConnectionRequestsHttpConnection(connection.RequestsHttpConnection):
     def __init__(self, *args, **kwargs):
         kwargs['headers'] = {
-            'sonarg-user': os.environ['elasticsearch.customHeaders.sonarg-user']
+            'sonarg-user': getSonarConfig()['elasticsearch.customHeaders']['sonarg-user']
         }
         super(SonarConnectionRequestsHttpConnection, self).__init__(*args, **kwargs)


### PR DESCRIPTION
They recently changed the configuration path to /etc/sonar/kibana.yml instead of the installation directory. I thought we must changed the way we load these configuration just to be more robust.