### PR TITLE
SES-1222: change scripted field key

### DIFF
--- a/elastalert/rule_type_definitions/compare_rules.py
+++ b/elastalert/rule_type_definitions/compare_rules.py
@@ -191,7 +191,7 @@ class ChangeRule(CompareRule):
                                                     time_clause]}},
                         'size': 1,
                         'script_fields': {
-                            "compare_key_field": {"script": {"inline": "'{}'".format(field), "lang": "sonar"}}
+                            "compare_key_field": {"script": {"source": "'{}'".format(field), "lang": "sonar"}}
                         }
                     }
                     request.extend([req_head, req_body])

--- a/elastalert/saved_source.py
+++ b/elastalert/saved_source.py
@@ -38,7 +38,7 @@ class SavedSource:
 
             for item in scripts:
                 if item.get('scripted'):
-                    scripted_fields[item['name']] = {"script": {"inline": item['script'], "lang": "sonar"}}
+                    scripted_fields[item['name']] = {"script": {"source": item['script'], "lang": "sonar"}}
 
         except Exception as e:
             elastalert_logger.exception('Failed to get scripted fields. Error {}'.format(e))


### PR DESCRIPTION
Issue: [SES-1222](https://jsonar.atlassian.net/browse/SES-1222)

Reflect the scripted field key change from `inline` to `source` in [`elasticsearch` v7](https://www.elastic.co/guide/en/elasticsearch/reference/7.0/search-request-script-fields.html)

